### PR TITLE
NAC-1901 remove unsupported date format

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 reMavenReleases=gcs://realeyes-maven/maven-releases
 reMavenSnapshots=gcs://realeyes-maven/maven-snapshots
 reMavenBase=gcs://realeyes-maven
-appVersion=0.1.2
+appVersion=0.1.3

--- a/src/main/kotlin/com/realeyes/hlsparserj/MediaPlaylist.kt
+++ b/src/main/kotlin/com/realeyes/hlsparserj/MediaPlaylist.kt
@@ -244,7 +244,7 @@ abstract class MediaPlaylist(version: PlaylistVersion, tags: MutableList<Unparse
         }
 
     private fun timeFromISO(dateStr: String?): Long {
-        val formats = listOf(SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX"), SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS"), SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ"))
+        val formats = listOf(SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS"), SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ"))
         val time = formats.tryParse(dateStr)
         return time?.time ?: 0
     }


### PR DESCRIPTION
Fixes support for older devices like Fire TVs
https://stackoverflow.com/questions/28373610/android-parse-string-to-date-unknown-pattern-character-x